### PR TITLE
Autorequire tacker package by tacker_config

### DIFF
--- a/lib/puppet/type/tacker_config.rb
+++ b/lib/puppet/type/tacker_config.rb
@@ -39,4 +39,8 @@ Puppet::Type.newtype(:tacker_config) do
 
     defaultto false
   end
+
+  autorequire(:package) do
+    'tacker'
+  end
 end

--- a/spec/unit/type/tacker_config_spec.rb
+++ b/spec/unit/type/tacker_config_spec.rb
@@ -52,7 +52,7 @@ describe 'Puppet::Type.type(:tacker_config)' do
 
   it 'should autorequire the package that install the file' do
     catalog = Puppet::Resource::Catalog.new
-    package = Puppet::Type.type(:package).new(:name => 'tacker-common')
+    package = Puppet::Type.type(:package).new(:name => 'tacker')
     catalog.add_resource package, @tacker_config
     dependency = @tacker_config.autorequire
     expect(dependency.size).to eq(1)


### PR DESCRIPTION
This patch ensure that tacker package which provide configuration files
will be installed before tacker_config will try change those files.